### PR TITLE
Fix slicing result set

### DIFF
--- a/src/main/resources/search.js
+++ b/src/main/resources/search.js
@@ -20,7 +20,7 @@ $(function () {
             var offsetStart = (this.page - 1) * this.pageSize;
             var offsetEnd = offsetStart + this.pageSize;
             if (offsetEnd > this.items.length - 1) {
-                offsetEnd = this.items.length - 1;
+                offsetEnd = this.items.length;
             }
 
             return items.slice(offsetStart, offsetEnd);


### PR DESCRIPTION
Other option would be to delete the whole condition. Does not seem to make a difference if you have a greater value than elements in the offsetEnd.
